### PR TITLE
ci: use full commit hash

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm run build # The build command of your project
     
       - name: Push
-        uses: s0/git-publish-subdir-action@develop
+        uses: s0/git-publish-subdir-action@399aab378450f99b7de6767f62b0d1dbfcb58b53
         env:
           REPO: self
           BRANCH: latest # The branch name where you want to push the assets


### PR DESCRIPTION
Pinning action to a branch poses a security threat.

Cf. https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
