### PR TITLE
feat: make moderators configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Automatically create the issue for the next release.
 Parameters:
   - `template-path`: Path to the template file. Default: `.github/ISSUE_TEMPLATE/RELEASE.md`
   - `package-path`: Path to the package.json (used for next version number). Default: `package.json`
+  - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
 
 ### Usage
 
@@ -38,6 +39,7 @@ jobs:
 Automatically create the issue for the next modeling weekly.
 Parameters:
   - `template-path`: Path to the template file. Default: `.github/ISSUE_TEMPLATE/WEEKLY_NOTE.md`
+  - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
 
 ### Usage
 

--- a/src/release-issue/action.yml
+++ b/src/release-issue/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: 'Relative path to the package.json'
     required: true
     default: 'package.json'
+  moderators-path:
+    description: 'Relative path to the list of moderators'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/release-issue/index.js
+++ b/src/release-issue/index.js
@@ -3,11 +3,13 @@ const github = require('@actions/github');
 
 const find = require('min-dash').find;
 
-const MODERATORS = require('../shared/moderators');
 const semver = require('semver');
 
+let MODERATORS;
 
 async function run() {
+
+  MODERATORS = await require('../shared/moderators');
 
   const RELEASE_TEMPLATE_CONFIG = {
     templatePath: core.getInput('template-path'),

--- a/src/shared/DEFAULT_MODERATORS.js
+++ b/src/shared/DEFAULT_MODERATORS.js
@@ -1,0 +1,7 @@
+module.exports = [
+  { idx: 0, fullName: 'Maciej Barelkowski', login: 'barmac' },
+  { idx: 1, fullName: 'Philipp Fromme', login: 'philippfromme' },
+  { idx: 2, fullName: 'Nico Rehwaldt', login: 'nikku' },
+  { idx: 3, fullName: 'Martin Stamm', login: 'marstamm' },
+  { idx: 4, fullName: 'Beatriz Mendes', login: 'smbea' }
+];

--- a/src/shared/moderators.js
+++ b/src/shared/moderators.js
@@ -1,7 +1,27 @@
-module.exports = [
-  { idx: 0, fullName: 'Maciej Barelkowski', login: 'barmac' },
-  { idx: 1, fullName: 'Philipp Fromme', login: 'philippfromme' },
-  { idx: 2, fullName: 'Nico Rehwaldt', login: 'nikku' },
-  { idx: 3, fullName: 'Martin Stamm', login: 'marstamm' },
-  { idx: 4, fullName: 'Beatriz Mendes', login: 'smbea' }
-];
+const DEFAULT_MODERATORS = require('./DEFAULT_MODERATORS');
+
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+const token = core.getInput('token');
+const moderatorsPath = core.getInput('moderators-path');
+
+const octokitRest = github.getOctokit(token).rest;
+const repository = github.context.payload.repository;
+
+const moderators = moderatorsPath && getModerators();
+
+module.exports = moderators || DEFAULT_MODERATORS;
+
+
+// helpers //////////////////////
+async function getModerators() {
+  const response = await octokitRest.repos.getContent({
+    repo: repository.name,
+    owner: repository.owner.login,
+    path: moderatorsPath
+  });
+
+  const encoded = Buffer.from(response.data.content, 'base64');
+  return JSON.parse(encoded.toString('utf-8'));
+}

--- a/src/weekly-notes/action.yml
+++ b/src/weekly-notes/action.yml
@@ -8,6 +8,8 @@ inputs:
     description: 'Relative path to the weekly template'
     required: true
     default: '.github/ISSUE_TEMPLATE/WEEKLY_NOTE.md'
+  moderators-path:
+    description: 'Relative path to the list of moderators'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -9,9 +9,11 @@ const {
   getWeek
 } = require('./util');
 
-const MODERATORS = require('../shared/moderators');
+let MODERATORS;
 
 async function run() {
+
+  MODERATORS = await require('../shared/moderators');
 
   const WEEKLY_TEMPLATE_LOCATION = {
     path: core.getInput('template-path')


### PR DESCRIPTION
Adds the option to make the moderators list configurable. Add a `moderators.json` to your repo and add the path as input to the action. The JSON content should look like the the return value of `src/shared/DEFAULT_MODERATORS.js`, e.g.:

```JSON
[
  { "idx": 0, "fullName": "Foo Bar", "login": "foobar" },
  { "idx": 1, "fullName": "Baz Bq", "login": "bazbq" },
  ...
]
```

related to https://github.com/camunda/team-hto/pull/11#discussion_r997117506
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
