### PR TITLE
feat(weekly-notes): allow parameterization of communityWorker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Automatically create the issue for the next modeling weekly.
 Parameters:
   - `template-path`: Path to the template file. Default: `.github/ISSUE_TEMPLATE/WEEKLY_NOTE.md`
   - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
+  - `community-worker`: Optional community worker flag. Set to 'false' to not assign a community worker, will default to true.
 
 ### Usage
 

--- a/src/weekly-notes/action.yml
+++ b/src/weekly-notes/action.yml
@@ -2,7 +2,7 @@ name: 'Open weekly issue'
 description: 'Create new release issue when the last one was closed'
 inputs:
   token:
-    description: 'GITHUB_TOKEN or a repo scoped PAT.'
+    description: 'GITHUB_TOKEN or a repo scoped PAT'
     default: ${{ github.token }}
   template-path:
     description: 'Relative path to the weekly template'
@@ -10,6 +10,8 @@ inputs:
     default: '.github/ISSUE_TEMPLATE/WEEKLY_NOTE.md'
   moderators-path:
     description: 'Relative path to the list of moderators'
+  community-worker:
+    description: 'Community worker = true|false. Set to 'false' to not assign a community worker, will default to true'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -25,6 +25,8 @@ async function run() {
 
   const token = core.getInput('token');
 
+  const includeCommunityWorker = core.getInput('community-worker') == 'false' ? false : true;
+
   const octokitRest = github.getOctokit(token).rest;
   const _getIssues = async (options) => {
     options = {
@@ -86,23 +88,30 @@ async function run() {
     fullName: nextWriterName
   } = getNextSummaryWriter(issue) || {};
 
-  // assign next community worker
-  const {
-    login: nextCommunityWorker,
-    fullName: nextCommunityWorkerName
-  } = getNextRoundRobin(issue, 2) || {};
+  // assign next community worker if community worker shall be assigned
+  let nextCommunityWorker, nextCommunityWorkerName = null;
+
+  if (includeCommunityWorker) {
+    ({
+      login: nextCommunityWorker,
+      fullName: nextCommunityWorkerName
+    } = getNextRoundRobin(issue, 2) || {});
+  }
 
   // create weekly note body
   const body = await createWeeklyNote(nextModerator, nextSummaryWriter, nextCommunityWorker);
 
   // create new issue
+  // filter out not-set roles
+  const assignees = [ nextModerator, nextCommunityWorker ].filter(a => a);
+
   const {
     data: createdIssue
   } = await _createIssue({
     body,
     title,
     labels: [ 'weekly', 'ready' ],
-    assignees: [ nextModerator, nextCommunityWorker ]
+    assignees
   });
 
   // add comment to closed issue for next moderator
@@ -110,7 +119,7 @@ async function run() {
     issue_number: issue.number,
     body: `Created [follow up weekly notes](${createdIssue.html_url}).
 
-Assigned @${nextCommunityWorker} as the community worker and @${nextModerator} as the next moderator.`
+Assigned${nextCommunityWorker ? ' @' + nextCommunityWorker + ' as the community worker and' : ''} @${nextModerator} as the next moderator.`
   });
 
   // send notification
@@ -122,7 +131,7 @@ The agenda for ${title} is up: ${createdIssue.html_url}. Feel free to add additi
 
 The moderator for this time will be ${nextModName}.
 The summary writer for this time will be ${nextWriterName}.
-The community worker until then will be ${nextCommunityWorkerName}.
+${nextCommunityWorker ? 'The community worker until then will be ' + nextCommunityWorkerName + '.' : ''}
 
 Best,
 your bot.`
@@ -143,7 +152,7 @@ your bot.`
     // substitute roles
     weeklyNote = weeklyNote.replace(/{{moderator}}/g, `@${nextMod}`);
     weeklyNote = weeklyNote.replace(/{{summary-writer}}/g, `@${nextWriter}`);
-    weeklyNote = weeklyNote.replace(/{{community-worker}}/g, `@${nextCommunityWorker}`);
+    weeklyNote = nextCommunityWorker ? weeklyNote.replace(/{{community-worker}}/g, `@${nextCommunityWorker}`) : weeklyNote;
 
     weeklyNote = withoutPrelude(weeklyNote);
 


### PR DESCRIPTION
This action is now used in other teams as well:

* https://github.com/camunda/team-hto/blob/main/.github/workflows/WEEKLY.yml
* https://github.com/camunda/engineering-leadership-team/blob/main/.github/workflows/WEEKLY.yml

It would be great to make the community worker optional:

* related to camunda/engineering-leadership-team#31

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
