### PR TITLE
chore(weekly-notes): Add verbose params for the community worker param

### DIFF
--- a/src/weekly-notes/action.yml
+++ b/src/weekly-notes/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: 'Relative path to the list of moderators'
   community-worker:
     description: 'Community worker = true|false. Set to false to not assign a community worker, will default to true'
+    required: false
+    default: true
+    type: boolean
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -25,7 +25,7 @@ async function run() {
 
   const token = core.getInput('token');
 
-  const includeCommunityWorker = core.getInput('community-worker') == 'false' ? false : true;
+  const includeCommunityWorker = core.getInput('community-worker') === 'true';
 
   const octokitRest = github.getOctokit(token).rest;
   const _getIssues = async (options) => {


### PR DESCRIPTION
A follow up on https://github.com/bpmn-io/actions/pull/6 as described in https://github.com/bpmn-io/actions/pull/6#discussion_r1065984838.

- explicitly defining the type of the `community-worker` input as well as its default value
- simplify logic for parsing the string value via `core.getInput`

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
