### PR TITLE
Allow to interpolate the previous weekly URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Parameters:
 ```yml
 # .github/workflows/RELEASE_ISSUE.yml
 name: Release Issue
-on: 
+on:
   issues:
     types: [closed]
 jobs:
@@ -42,12 +42,13 @@ Parameters:
   - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
   - `roles`: A comma-separated list of the roles you want to assign in the weekly.
 
+
 ### Usage
 
 ```yml
 # .github/workflows/WEEKLY.yml
 name: Weekly
-on: 
+on:
   issues:
     types: [closed]
 jobs:
@@ -60,4 +61,37 @@ jobs:
        with:
          template-path: '.docs/WEEKLY_TEMPLATE.md'
          roles: 'moderator,summary-writer,community-worker'
+```
+
+### Template file syntax
+
+The template file support the following placeholders:
+
+* `{{previousIssueURL}}`: this will be replace by the URL of the previous weekly issue
+* `{{$role}}`: a placeholder containing one of the specified role (from the `roles` input of the action) will be replaced by the GitHub handler of the person who has been assigned this role.
+
+Also, the Markdown preamble will be parsed out and removed from the final issue body.
+
+For instance:
+
+```markdown
+---
+name: Weekly meeting
+about: Create a new weekly team meeting note.
+labels:
+  - weekly
+---
+
+### Roles this week
+
+| Role | DRI |
+|---|---|
+| Moderator | {{moderator}} |
+| Summary Writer | {{summary-writer}} |
+
+⇨ Previous weekly meeting: {{previousIssueURL}}
+
+### Agenda
+
+* [ ] Discuss weekly things!
 ```

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -88,7 +88,7 @@ async function run() {
 
 
   // create weekly note body
-  const body = await createWeeklyNote(assignedRoles);
+  const body = await createWeeklyNote(issue.url, assignedRoles);
 
   // create new issue
   const assignees = assignedRoles.map(({ login }) => login);
@@ -114,7 +114,7 @@ async function run() {
 Assigned ${nextRoleMessage}.`
   });
 
-  async function createWeeklyNote(replaceOptions) {
+  async function createWeeklyNote(previousIssueURL, roles) {
 
     const response = await octokitRest.repos.getContent({
       repo: repository.name,
@@ -127,10 +127,11 @@ Assigned ${nextRoleMessage}.`
     let weeklyNote = encoded.toString('utf-8');
 
     // substitute roles
-    replaceOptions.forEach(({ login, role }) => {
+    roles.forEach(({ login, role }) => {
       weeklyNote = weeklyNote.replaceAll(`{{${role}}}`, `@${login}`);
     });
 
+    weeklyNote = weeklyNote.replaceAll(`{{previousIssueURL}}`, `${previousIssueURL}`);
     weeklyNote = withoutPrelude(weeklyNote);
 
     return weeklyNote;


### PR DESCRIPTION
This adds a new template placeholder `previousIssueURL` that allows to add into the weekly issue a link to the previous weekly issue.

If the placeholder doesn't exist, the action should work as before, but this will only work if [the GitHub Action is triggered from an "issue" event](https://docs.github.com/en/webhooks/webhook-events-and-payloads#issues).

The README is also extended a bit to explain how the template should be written.

Closes: #12
