### PR TITLE
feat: support `labels` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Parameters:
   - `template-path`: Path to the template file. Default: `.github/ISSUE_TEMPLATE/RELEASE.md`
   - `package-path`: Path to the package.json (used for next version number). Default: `package.json`
   - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
+  - `labels`: A comma-separated list of the labels you want to assign in the release issue.
 
 ### Usage
 
@@ -30,7 +31,8 @@ jobs:
        uses: bpmn-io/actions/release-issue@latest
        with:
          template-path: '.docs/RELEASE.md'
-         package-path: 'app/package.json'
+         package-path: 'app/package.json',
+         labels: 'release,ready'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
        uses: bpmn-io/actions/release-issue@latest
        with:
          template-path: '.docs/RELEASE.md'
-         package-path: 'app/package.json',
+         package-path: 'app/package.json'
          labels: 'release,ready'
 ```
 

--- a/src/release-issue/action.yml
+++ b/src/release-issue/action.yml
@@ -14,6 +14,9 @@ inputs:
     default: 'package.json'
   moderators-path:
     description: 'Relative path to the list of moderators'
+  labels:
+    description: 'Labels to set for the created issue as a comma separated list'
+    default: 'release,ready'
 outputs:
   assignee:
     description: 'The assignee of the newly created issue'

--- a/src/release-issue/index.js
+++ b/src/release-issue/index.js
@@ -22,6 +22,8 @@ async function run() {
 
   const token = core.getInput('token');
 
+  const labels = core.getInput('labels');
+
   const octokitRest = github.getOctokit(token).rest;
 
   const _getNextMinor = async function() {
@@ -130,7 +132,7 @@ async function run() {
   } = await _createIssue({
     body,
     title,
-    labels: [ 'release', 'ready' ],
+    labels: labels.split(',').map(l => l.trim()),
     assignees: [ nextReleaseCommander ]
   });
 


### PR DESCRIPTION
This makes it possible to configure the labels to be set.

I thought about hard coding `release`, but I believe it's okay to say "you know what you do when you use that option".  