### PR TITLE
feat: weeks interval in weekly-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Parameters:
   - `template-path`: Path to the template file. Default: `.github/ISSUE_TEMPLATE/WEEKLY_NOTE.md`
   - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
   - `roles`: A comma-separated list of the roles you want to assign in the weekly.
+  - `week-interval`: The jump of the weeks used in the GitHub issue title. This is useful if you want to open the issue every 2 weeks or so.
 
 
 ### Usage

--- a/src/weekly-notes/action.yml
+++ b/src/weekly-notes/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: 'moderator,summary-writer,community-worker'
     type: string
-  week-internval:
+  week-interval:
     description: 'The jump of the weeks used in the GitHub issue title. This is useful if you want to open the issue every 2 weeks or so.'
     required: false
     default: 1

--- a/src/weekly-notes/action.yml
+++ b/src/weekly-notes/action.yml
@@ -21,6 +21,11 @@ inputs:
     required: false
     default: 'moderator,summary-writer,community-worker'
     type: string
+  week-internval:
+    description: 'The jump of the weeks used in the GitHub issue title. This is useful if you want to open the issue every 2 weeks or so.'
+    required: false
+    default: 1
+    type: number
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -30,6 +30,8 @@ async function run() {
     .map(r => r.trim())
     .filter(r => includeCommunityWorker || r !== 'community-worker'); // for backwards compatibility
 
+  const weekInterval = core.getInput('week-internval')
+
   const octokitRest = github.getOctokit(token).rest;
   const _getIssues = async (options) => {
     options = {
@@ -162,7 +164,7 @@ function getIssueTitle() {
   const currentWeek = getCurrentWeek(),
         currentWeekNr = currentWeek.weekNumber,
         currentYearNr = currentWeek.year,
-        upcomingWeekNr = currentWeekNr == 52 ? 1 : currentWeekNr + 1,
+        upcomingWeekNr = currentWeekNr == 52 ? 1 : currentWeekNr + weekInterval,
         upcomingYearNr = upcomingWeekNr == 1 ? currentYearNr + 1 : currentYearNr;
 
   return `W${upcomingWeekNr} - ${upcomingYearNr}`;

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -30,7 +30,7 @@ async function run() {
     .map(r => r.trim())
     .filter(r => includeCommunityWorker || r !== 'community-worker'); // for backwards compatibility
 
-  const weekInterval = core.getInput('week-internval')
+  const weekInterval = core.getInput('week-interval');
 
   const octokitRest = github.getOctokit(token).rest;
   const _getIssues = async (options) => {


### PR DESCRIPTION
Hi team :wave:

The Camunda Distro team is using the `weekly-notes` action but our team meeting is fortnightly (every 2 weeks).

So this PR supports setting the week interval so we can set the jump in the issue title.
It's still 1 by default so no behavior change, but if the user sets `week-interval: 2` and the flow runs today (year week 21) the title will be `W23 - 2024` instead of `W22 - 2024`.
