### PR TITLE
fix: Fix week interval

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,24 @@
+name: CI
+on: [ push, pull_request ]
+jobs:
+  Build:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        node-version: [ 20 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run all

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "The custom github actions used by the bpmn-io team",
   "scripts": {
+    "all": "run-s test build",
     "build": "run-s build:release-issue build:weekly-notes",
     "build:release-issue": "ncc build src/release-issue/index.js -o dist/release-issue/ && copyfiles -f src/release-issue/action.yml dist/release-issue",
     "build:weekly-notes": "ncc build src/weekly-notes/index.js -o dist/weekly-notes/ && copyfiles -f src/weekly-notes/action.yml dist/weekly-notes",

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -30,8 +30,6 @@ async function run() {
     .map(r => r.trim())
     .filter(r => includeCommunityWorker || r !== 'community-worker'); // for backwards compatibility
 
-  const weekInterval = core.getInput('week-interval');
-
   const octokitRest = github.getOctokit(token).rest;
   const _getIssues = async (options) => {
     options = {
@@ -164,7 +162,7 @@ function getIssueTitle() {
   const currentWeek = getCurrentWeek(),
         currentWeekNr = currentWeek.weekNumber,
         currentYearNr = currentWeek.year,
-        upcomingWeekNr = currentWeekNr == 52 ? 1 : currentWeekNr + weekInterval,
+        upcomingWeekNr = currentWeekNr == 52 ? 1 : currentWeekNr + core.getInput('week-interval'),
         upcomingYearNr = upcomingWeekNr == 1 ? currentYearNr + 1 : currentYearNr;
 
   return `W${upcomingWeekNr} - ${upcomingYearNr}`;

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -162,7 +162,7 @@ function getIssueTitle() {
   const currentWeek = getCurrentWeek(),
         currentWeekNr = currentWeek.weekNumber,
         currentYearNr = currentWeek.year,
-        upcomingWeekNr = currentWeekNr == 52 ? 1 : currentWeekNr + core.getInput('week-interval'),
+        upcomingWeekNr = (currentWeekNr + core.getInput('week-interval')) % 52,
         upcomingYearNr = upcomingWeekNr == 1 ? currentYearNr + 1 : currentYearNr;
 
   return `W${upcomingWeekNr} - ${upcomingYearNr}`;

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -131,7 +131,7 @@ Assigned ${nextRoleMessage}.`
       weeklyNote = weeklyNote.replaceAll(`{{${role}}}`, `@${login}`);
     });
 
-    weeklyNote = weeklyNote.replaceAll(`{{previousIssueURL}}`, `${previousIssueURL}`);
+    weeklyNote = weeklyNote.replaceAll('{{previousIssueURL}}', `${previousIssueURL}`);
     weeklyNote = withoutPrelude(weeklyNote);
 
     return weeklyNote;

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -159,10 +159,11 @@ function getCurrentWeek() {
 }
 
 function getIssueTitle() {
-  const currentWeek = getCurrentWeek(),
+  const weekInterval = core.getInput('week-interval'),
+        currentWeek = getCurrentWeek(),
         currentWeekNr = currentWeek.weekNumber,
         currentYearNr = currentWeek.year,
-        upcomingWeekNr = (currentWeekNr + core.getInput('week-interval')) % 52,
+        upcomingWeekNr = (currentWeekNr + weekInterval - 1) % 52 + 1,
         upcomingYearNr = upcomingWeekNr == 1 ? currentYearNr + 1 : currentYearNr;
 
   return `W${upcomingWeekNr} - ${upcomingYearNr}`;

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -1,7 +1,7 @@
 
 /**
  * @typedef {Object} CalendarWeek
- * @property {number} weekNumber
+ * @property {number} weekNumber ISO week number 1-53
  * @property {number} year
  */
 


### PR DESCRIPTION
https://github.com/bpmn-io/actions/pull/16 broke the action ([see this run in the HTO repo](https://github.com/camunda/team-hto/actions/runs/9271367930/job/25506624289))

This was happening because `weekInterval` was out of the scope of `getIssueTitle`