### PR TITLE
fix Cannot read properties of null (reading 'login') 

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -11,8 +11,8 @@ const { findIndex } = require('min-dash');
  *
  * @return {Assignee | null}
  */
-function getNextAssignee(candidates, lastAssignee, offset = 1) {
-  const lastIndex = findIndex(candidates, c => c.login === lastAssignee.login);
+function getNextAssignee(candidates, lastAssignee={login:""}, offset = 1) {
+  const lastIndex = findIndex(candidates, c => c.login === lastAssignee?.login);
 
   // ensure assignee was a valid moderator
   if (lastIndex === -1) {


### PR DESCRIPTION
This PR fixes TypeError in the this code 
"const lastIndex = findIndex(candidates, c => c.login === lastAssignee.login);"
 people facing this problem 
"TypeError: Cannot read properties of null (reading 'login')
    at /home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:29256:73
    at /home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:31378:9
    at forEach (/home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:31440:16)
    at findIndex (/home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:31377:3)
    at getNextAssignee (/home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:29256:21)
    at /home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:32262:10
    at Array.map (<anonymous>)
    at run (/home/runner/work/_actions/bpmn-io/actions/latest/weekly-notes/index.js:32259:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"

solution :=

function getNextAssignee(candidates, lastAssignee={login:""}, offset = 1) {
  const lastIndex = findIndex(candidates, c => c.login === lastAssignee?.login);

  // ensure assignee was a valid moderator
  if (lastIndex === -1) {
    return null;
  }

  return candidates[(lastIndex + offset) % candidates.length];
}

assign a default value in getNextAssignee function parameter lastAssignee={login:""} so peoples don't face this typeError.

Fixes #27 