### PR TITLE
feat: add setup action

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "all": "run-s lint test build",
     "lint": "eslint .",
-    "build": "run-s build:release-issue build:weekly-notes",
+    "build": "run-s build:*",
     "build:release-issue": "ncc build src/release-issue/index.js -o dist/release-issue/ && copyfiles -f src/release-issue/action.yml dist/release-issue",
     "build:weekly-notes": "ncc build src/weekly-notes/index.js -o dist/weekly-notes/ && copyfiles -f src/weekly-notes/action.yml dist/weekly-notes",
+    "build:setup": "mkdir -p dist/setup && copyfiles -f src/setup/action.yml dist/setup",
     "test": "node test/test.js"
   },
   "keywords": [

--- a/src/setup/action.yml
+++ b/src/setup/action.yml
@@ -1,0 +1,20 @@
+name: 'Setup'
+description: 'Performs CI setup for bpmn.io projects'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup puppeteer/chrome apparmor profile
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        cat | sudo tee /etc/apparmor.d/chrome-puppeteer <<EOF
+        abi <abi/4.0>,
+        include <tunables/global>
+
+        profile chrome /@{HOME}/.cache/puppeteer/chrome/*/chrome-linux64/chrome flags=(unconfined) {
+          userns,
+
+          include if exists <local/chrome>
+        }
+        EOF
+        sudo service apparmor reload


### PR DESCRIPTION
### Proposed Changes

Adds a `setup` action that can be used to bootstrap the environment. Can be integrated easily into _any_ CI flow:

```yaml
name: CI
on: [ push, pull_request ]
jobs:
  build:
    strategy:
      matrix:
        os: [ ubuntu-latest ]
    runs-on: ${{ matrix.os }}
    steps:
    ...
    - name: Project setup
      uses: bpmn-io/actions/setup@latest
    - name: Build examples
      run: npm run build
```

Related to https://github.com/bpmn-io/internal-docs/issues/1115

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
