### PR TITLE
feat: use Google Chrome sandbox in setup

### DIFF
--- a/src/setup/action.yml
+++ b/src/setup/action.yml
@@ -3,50 +3,13 @@ description: 'Performs CI setup for bpmn.io projects'
 runs:
   using: "composite"
   steps:
-    - name: Setup puppeteer/chrome apparmor profile
+    - name: Setup chromium sandbox
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        cat | sudo tee /etc/apparmor.d/chrome-puppeteer <<EOF
-        abi <abi/4.0>,
-        include <tunables/global>
+        SANDBOX_LOCATION=/opt/google/chrome/chrome-sandbox
 
-        profile chrome /@{HOME}/.cache/puppeteer/chrome/*/chrome-linux64/chrome flags=(unconfined) {
-          userns,
+        sudo chown root $SANDBOX_LOCATION
+        sudo chmod 4755 $SANDBOX_LOCATION
 
-          include if exists <local/chrome>
-        }
-        EOF
-        sudo service apparmor reload
-
-    - name: Setup electron apparmor profile
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        cat | sudo tee /etc/apparmor.d/electron <<EOF
-        abi <abi/4.0>,
-        include <tunables/global>
-
-        profile electron /@{HOME}/**/node_modules/electron/dist/electron flags=(unconfined) {
-          userns,
-
-          include if exists <local/electron>
-        }
-        EOF
-        sudo service apparmor reload
-
-    - name: Setup camunda-modeler apparmor profile
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        cat | sudo tee /etc/apparmor.d/camunda-modeler <<EOF
-        abi <abi/4.0>,
-        include <tunables/global>
-
-        profile camunda-modeler /@{HOME}/**/camunda-modeler-*/camunda-modeler-*/camunda-modeler flags=(unconfined) {
-          userns,
-
-          include if exists <local/camunda-modeler>
-        }
-        EOF
-        sudo service apparmor reload
+        echo "CHROME_DEVEL_SANDBOX=$SANDBOX_LOCATION" >> "$GITHUB_ENV"


### PR DESCRIPTION
### Proposed Changes

This PR aims to fix the apparmor problem for all.

This is suggested as the safest way in https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md#option-3_the-safest-way 
Ubuntu runners have Google Chrome preinstalled, cf. https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
