### PR TITLE
fix: setup apparmor for camunda-modeler

### DIFF
--- a/src/setup/action.yml
+++ b/src/setup/action.yml
@@ -13,3 +13,17 @@ runs:
         sudo chmod 4755 $SANDBOX_LOCATION
 
         echo "CHROME_DEVEL_SANDBOX=$SANDBOX_LOCATION" >> "$GITHUB_ENV"
+
+    - name: Setup camunda-modeler apparmor profile # required for jobs running camunda-modeler executable
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        cat | sudo tee /etc/apparmor.d/camunda-modeler <<EOF
+        abi <abi/4.0>,
+        include <tunables/global>
+        profile camunda-modeler /@{HOME}/**/camunda-modeler-*/camunda-modeler-*/camunda-modeler flags=(unconfined) {
+          userns,
+          include if exists <local/camunda-modeler>
+        }
+        EOF
+        sudo service apparmor reload


### PR DESCRIPTION
### Proposed Changes

This is required to run electron on Ubuntu. https://github.com/bpmn-io/actions/pull/36 was too eager because it broke electron-based workflows.
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
