### PR TITLE
fix: save assignee in the issue contents

### DIFF
--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -10,7 +10,11 @@ const {
   getNextIssueTitle
 } = require('./util');
 
-const { getNextAssignee } = require('../shared/util');
+const {
+  getFirstAssignee,
+  getNextAssignee,
+  withAssignee
+} = require('../shared/util');
 
 async function run() {
 
@@ -78,6 +82,7 @@ async function run() {
 
     weeklyNote = weeklyNote.replaceAll('{{previousIssueURL}}', `${previousIssueURL}`);
     weeklyNote = withoutPrelude(weeklyNote);
+    weeklyNote = withAssignee(weeklyNote, assignedRoles[0].login);
 
     return weeklyNote;
   };
@@ -109,10 +114,13 @@ async function run() {
     .map(r => r.trim())
     .filter(r => includeCommunityWorker || r !== 'community-worker'); // for backwards compatibility
 
+  // parse assignee from issue body or use issue assignee as fallback
+  const assignee = getFirstAssignee(issue.body) || issue.assignee;
+
   const assignedRoles = roles.map((role, index) => {
     return {
       role,
-      ...getNextAssignee(MODERATORS, issue.assignee, index + 1)
+      ...getNextAssignee(MODERATORS, assignee, index + 1)
     };
   });
 

--- a/src/weekly-notes/test.js
+++ b/src/weekly-notes/test.js
@@ -1,46 +1,163 @@
 const { expect } = require('chai');
 const {
-  getNextIssueTitle
+  getNextIssueTitle,
+  getFirstAssignee,
+  withAssignee
 } = require('./util.js');
 
-describe('weekly-notes/util#getNextIssueTitle', function() {
+describe('weekly-notes/util', function() {
 
-  it('should calculate next week title correctly for week 1', function() {
-    expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 })).to.equal('W2 - 2000');
+  describe('#getNextIssueTitle', function() {
+
+    it('should calculate next week title correctly for week 1', function() {
+      expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 })).to.equal('W2 - 2000');
+    });
+
+
+    it('should calculate next week title correctly for 2 weeks ahead from week 1', function() {
+      expect(getNextIssueTitle(2, { weekNumber: 1, year: 2000 })).to.equal('W3 - 2000');
+    });
+
+
+    it('should calculate next week title correctly for week 5', function() {
+      expect(getNextIssueTitle(1, { weekNumber: 5, year: 2000 })).to.equal('W6 - 2000');
+    });
+
+
+    it('should calculate next week title correctly for 2 weeks ahead from week 5', function() {
+      expect(getNextIssueTitle(2, { weekNumber: 5, year: 2000 })).to.equal('W7 - 2000');
+    });
+
+
+    it('should handle year rollover from week 52', function() {
+      expect(getNextIssueTitle(1, { weekNumber: 52, year: 2000 })).to.equal('W1 - 2001');
+    });
+
+
+    it('should handle year rollover for 2 weeks ahead from week 52', function() {
+      expect(getNextIssueTitle(2, { weekNumber: 52, year: 2000 })).to.equal('W2 - 2001');
+    });
+
+
+    it('should handle year rollover from week 53', function() {
+      expect(getNextIssueTitle(1, { weekNumber: 53, year: 2000 })).to.equal('W1 - 2001');
+    });
+
+
+    it('should handle year rollover for 2 weeks ahead from week 53', function() {
+      expect(getNextIssueTitle(2, { weekNumber: 53, year: 2000 })).to.equal('W2 - 2001');
+    });
   });
 
 
-  it('should calculate next week title correctly for 2 weeks ahead from week 1', function() {
-    expect(getNextIssueTitle(2, { weekNumber: 1, year: 2000 })).to.equal('W3 - 2000');
+  describe('#getFirstAssignee', function() {
+
+    it('should extract assignee from issue contents', function() {
+
+      // given
+      const issueContents = 'Some issue content\n\n<!-- assignee: @johndoe -->';
+
+      // when
+      const assignee = getFirstAssignee(issueContents);
+
+      // then
+      expect(assignee).to.equal('johndoe');
+    });
+
+
+    it('should return null when no assignee tag is present', function() {
+
+      // given
+      const issueContents = 'Some issue content without assignee';
+
+      // when
+      const assignee = getFirstAssignee(issueContents);
+
+      // then
+      expect(assignee).to.be.null;
+    });
+
+
+    it('should return first assignee when multiple assignee tags are present', function() {
+
+      // given
+      const issueContents = 'Some content\n<!-- assignee: @first -->\nMore content\n<!-- assignee: @second -->';
+
+      // when
+      const assignee = getFirstAssignee(issueContents);
+
+      // then
+      expect(assignee).to.equal('first');
+    });
+
+    it('should handle assignee tag in the middle of content', function() {
+
+      // given
+      const issueContents = 'Start content\n<!-- assignee: @username -->\nEnd content';
+
+      // when
+      const assignee = getFirstAssignee(issueContents);
+
+      // then
+      expect(assignee).to.equal('username');
+    });
+
+
+    it('should return null for malformed assignee tag', function() {
+
+      // given
+      const issueContents = 'Some content\n<!-- assignee: username -->\nMore content';
+
+      // when
+      const assignee = getFirstAssignee(issueContents);
+
+      // then
+      expect(assignee).to.be.null;
+    });
   });
 
 
-  it('should calculate next week title correctly for week 5', function() {
-    expect(getNextIssueTitle(1, { weekNumber: 5, year: 2000 })).to.equal('W6 - 2000');
-  });
+  describe('#withAssignee', function() {
+
+    it('should add assignee tag to issue contents', function() {
+
+      // given
+      const issueContents = 'Original issue content';
+
+      // when
+      const result = withAssignee(issueContents, 'johndoe');
+
+      // then
+      expect(result).to.equal('Original issue content\n\n<!-- assignee: @johndoe -->');
+    });
 
 
-  it('should calculate next week title correctly for 2 weeks ahead from week 5', function() {
-    expect(getNextIssueTitle(2, { weekNumber: 5, year: 2000 })).to.equal('W7 - 2000');
-  });
+    it('should add assignee tag to empty content', function() {
+
+      // given
+      const issueContents = '';
+
+      // when
+      const result = withAssignee(issueContents, 'username');
+
+      // then
+      expect(result).to.equal('\n\n<!-- assignee: @username -->');
+    });
 
 
-  it('should handle year rollover from week 52', function() {
-    expect(getNextIssueTitle(1, { weekNumber: 52, year: 2000 })).to.equal('W1 - 2001');
-  });
+    it('should throw error when assignee is not provided', function() {
 
+      // given
+      const issueContents = 'Some content';
 
-  it('should handle year rollover for 2 weeks ahead from week 52', function() {
-    expect(getNextIssueTitle(2, { weekNumber: 52, year: 2000 })).to.equal('W2 - 2001');
-  });
-
-
-  it('should handle year rollover from week 53', function() {
-    expect(getNextIssueTitle(1, { weekNumber: 53, year: 2000 })).to.equal('W1 - 2001');
-  });
-
-
-  it('should handle year rollover for 2 weeks ahead from week 53', function() {
-    expect(getNextIssueTitle(2, { weekNumber: 53, year: 2000 })).to.equal('W2 - 2001');
+      // then
+      [
+        null,
+        undefined,
+        ''
+      ].forEach(value => {
+        expect(() => withAssignee(issueContents, value)).to.throw('assignee must be provided');
+      });
+    });
   });
 });

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -60,3 +60,18 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
 
   return `W${upcomingWeekNr} - ${upcomingYearNr}`;
 };
+
+module.exports.getFirstAssignee = function getFirstAssignee(issueContents) {
+  const assigneeRegex = /<!-- assignee: @(\w+) -->/g;
+  const match = assigneeRegex.exec(issueContents);
+  return match ? match[1] : null;
+};
+
+module.exports.withAssignee = function withAssignee(issueContents, assignee) {
+  if (!assignee) {
+    throw new Error('assignee must be provided');
+  }
+
+  const assigneeTag = `<!-- assignee: @${assignee} -->`;
+  return `${issueContents}\n\n${assigneeTag}`;
+};


### PR DESCRIPTION

### Proposed Changes

Assignee will be saved to the issue and retrieved from as we cannot rely on the `issue#assignee` field for the first assignee. We keep the old way as a fallback to not reset all of the flows.

Closes #38

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
