### PR TITLE
Fix getting assignee

### DIFF
--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -19,10 +19,12 @@ const {
 async function run() {
 
   const MODERATORS = await require('../shared/moderators');
+  core.debug(`Available Moderators: ${JSON.stringify(MODERATORS)}`);
 
   const WEEKLY_TEMPLATE_PATH = core.getInput('template-path');
 
   const issue = github.context.payload.issue;
+  core.debug(`Issue: ${JSON.stringify(issue)}`);
 
   const repository = github.context.payload.repository;
 
@@ -116,6 +118,7 @@ async function run() {
 
   // parse assignee from issue body or use issue assignee as fallback
   const assignee = getFirstAssignee(issue.body) || issue.assignee;
+  core.debug(`Assignee: ${assignee}`);
 
   const assignedRoles = roles.map((role, index) => {
     return {
@@ -123,6 +126,7 @@ async function run() {
       ...getNextAssignee(MODERATORS, assignee, index + 1)
     };
   });
+  core.debug(`Next Roles: ${JSON.stringify(assignedRoles)}`);
 
   // create weekly note body
   const body = await _createWeeklyNote(issue.url, assignedRoles);

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -118,7 +118,7 @@ async function run() {
 
   // parse assignee from issue body or use issue assignee as fallback
   const assignee = getFirstAssignee(issue.body) || issue.assignee;
-  core.debug(`Assignee: ${assignee}`);
+  core.debug(`Assignee: ${JSON.stringify(assignee)}`);
 
   const assignedRoles = roles.map((role, index) => {
     return {

--- a/src/weekly-notes/test.js
+++ b/src/weekly-notes/test.js
@@ -61,7 +61,7 @@ describe('weekly-notes/util', function() {
       const assignee = getFirstAssignee(issueContents);
 
       // then
-      expect(assignee).to.equal('johndoe');
+      expect(assignee.login).to.equal('johndoe');
     });
 
 
@@ -87,7 +87,7 @@ describe('weekly-notes/util', function() {
       const assignee = getFirstAssignee(issueContents);
 
       // then
-      expect(assignee).to.equal('first');
+      expect(assignee.login).to.equal('first');
     });
 
     it('should handle assignee tag in the middle of content', function() {
@@ -99,7 +99,7 @@ describe('weekly-notes/util', function() {
       const assignee = getFirstAssignee(issueContents);
 
       // then
-      expect(assignee).to.equal('username');
+      expect(assignee.login).to.equal('username');
     });
 
 
@@ -125,7 +125,7 @@ describe('weekly-notes/util', function() {
       const issueContents = 'Original issue content';
 
       // when
-      const result = withAssignee(issueContents, 'johndoe');
+      const result = withAssignee(issueContents, { login: 'johndoe' });
 
       // then
       expect(result).to.equal('Original issue content\n\n<!-- assignee: @johndoe -->');
@@ -138,7 +138,7 @@ describe('weekly-notes/util', function() {
       const issueContents = '';
 
       // when
-      const result = withAssignee(issueContents, 'username');
+      const result = withAssignee(issueContents, { login: 'username' });
 
       // then
       expect(result).to.equal('\n\n<!-- assignee: @username -->');

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -61,17 +61,25 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
   return `W${upcomingWeekNr} - ${upcomingYearNr}`;
 };
 
+/**
+ * @param {string} issueContents
+ * @returns {import("../shared/util").Assignee}
+ */
 module.exports.getFirstAssignee = function getFirstAssignee(issueContents) {
   const assigneeRegex = /<!-- assignee: @(\w+) -->/g;
   const match = assigneeRegex.exec(issueContents);
-  return match ? match[1] : null;
+  return match ? { login: match[1] } : null;
 };
 
+/**
+ * @param {string} issueContents
+ * @param {import("../shared/util").Assignee} assignee
+ */
 module.exports.withAssignee = function withAssignee(issueContents, assignee) {
   if (!assignee) {
     throw new Error('assignee must be provided');
   }
 
-  const assigneeTag = `<!-- assignee: @${assignee} -->`;
+  const assigneeTag = `<!-- assignee: @${assignee.login} -->`;
   return `${issueContents}\n\n${assigneeTag}`;
 };


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

By reading the assignee just from the body its type changed from `Assignee` (`{login: string}`) to `string`. This adjust the newly added helper functions to conform to the correct type

Also added some debug statements that can be activated during reruns of the action to help analyze future issues (https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging)

Run with debug enabled: 
<img width="2237" height="503" alt="image" src="https://github.com/user-attachments/assets/01fc8406-6d35-4c7e-8d60-bf14decedc34" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
