### PR TITLE
feat: Support issue title template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Automatically create the issue for the next modeling weekly.
 - `summary-writer-assignee`: Summary writer assigned, if assignment took place
 - `community-worker-assignee`: Community worker assigned, if assignment took place
 - `html-url`: URL of the newly created weekly note, if one got created
-- `title-template`: Optional issue title template literal that can reference the `${week}` and the `${year}`.
+- `title-template`: Optional issue title template literal that can reference the `{{week}}` and the `{{year}}`.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Automatically create the issue for the next release.
 - `package-path`: Path to the package.json (used for next version number). Default: `package.json`
 - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
 - `labels`: A comma-separated list of the labels you want to assign in the release issue.
-- `title-template`: Optional issue title template literal that can reference the `${week}` and the `${year}`.
 
 ### Outputs
 
@@ -60,6 +59,7 @@ Automatically create the issue for the next modeling weekly.
 - `summary-writer-assignee`: Summary writer assigned, if assignment took place
 - `community-worker-assignee`: Community worker assigned, if assignment took place
 - `html-url`: URL of the newly created weekly note, if one got created
+- `title-template`: Optional issue title template literal that can reference the `${week}` and the `${year}`.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Automatically create the issue for the next release.
 - `package-path`: Path to the package.json (used for next version number). Default: `package.json`
 - `moderators-path`: Optional path to the moderators file. Defaults to the bpmn-io moderators.
 - `labels`: A comma-separated list of the labels you want to assign in the release issue.
+- `title-template`: Optional issue title template literal that can reference the `${week}` and the `${year}`.
 
 ### Outputs
 

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -97,7 +97,7 @@ async function run() {
 
   const currentWeek = getCurrentWeek();
   const weekInterval = parseInt(core.getInput('week-interval'), 10);
-  
+
   // set title to upcoming calendar week + year
   const title = getNextIssueTitle(
     weekInterval,

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -23,6 +23,8 @@ async function run() {
 
   const WEEKLY_TEMPLATE_PATH = core.getInput('template-path');
 
+  const TITLE_TEMPLATE = core.getInput('title-template');
+
   const issue = github.context.payload.issue;
   core.debug(`Issue: ${JSON.stringify(issue)}`);
 
@@ -95,11 +97,12 @@ async function run() {
 
   const currentWeek = getCurrentWeek();
   const weekInterval = parseInt(core.getInput('week-interval'), 10);
-
+  
   // set title to upcoming calendar week + year
   const title = getNextIssueTitle(
     weekInterval,
-    currentWeek
+    currentWeek,
+    TITLE_TEMPLATE
   );
 
   // don't create weekly twice

--- a/src/weekly-notes/test.js
+++ b/src/weekly-notes/test.js
@@ -19,7 +19,7 @@ describe('weekly-notes/util', function() {
     });
 
     it('should calculate next week title correctly for week 1 with a custom template', function() {
-      expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 }, 'Custom Template in week ${week} of year ${year}')).to.equal('Custom Template in week 2 of year 2000');
+      expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 }, 'Custom Template in week {{week}} of year {{year}}')).to.equal('Custom Template in week 2 of year 2000');
     });
 
     it('should calculate next week title correctly for 2 weeks ahead from week 1', function() {
@@ -60,7 +60,7 @@ describe('weekly-notes/util', function() {
   describe('#evaluateTemplate', function() {
 
     it('should evaluate template with provided data', function() {
-      const template = 'Hello ${name}';
+      const template = 'Hello {{name}}';
       const data = { name: 'World' };
       const result = evaluateTemplate(template, data);
       expect(result).to.equal('Hello World');

--- a/src/weekly-notes/test.js
+++ b/src/weekly-notes/test.js
@@ -2,7 +2,8 @@ const { expect } = require('chai');
 const {
   getNextIssueTitle,
   getFirstAssignee,
-  withAssignee
+  withAssignee,
+  evaluateTemplate
 } = require('./util.js');
 
 describe('weekly-notes/util', function() {
@@ -13,6 +14,13 @@ describe('weekly-notes/util', function() {
       expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 })).to.equal('W2 - 2000');
     });
 
+    it('should calculate next week title correctly for week 1 with an empty custom template', function() {
+      expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 }, '')).to.equal('W2 - 2000');
+    });
+
+    it('should calculate next week title correctly for week 1 with a custom template', function() {
+      expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 }, 'Custom Template in week ${week} of year ${year}')).to.equal('Custom Template in week 2 of year 2000');
+    });
 
     it('should calculate next week title correctly for 2 weeks ahead from week 1', function() {
       expect(getNextIssueTitle(2, { weekNumber: 1, year: 2000 })).to.equal('W3 - 2000');
@@ -49,6 +57,23 @@ describe('weekly-notes/util', function() {
     });
   });
 
+  describe('#evaluateTemplate', function() {
+
+    it('should evaluate template with provided data', function() {
+      const template = 'Hello ${name}';
+      const data = { name: 'World' };
+      const result = evaluateTemplate(template, data);
+      expect(result).to.equal('Hello World');
+    });
+
+    it('should evaluate a template without placeholders', function() {
+      const template = 'Hello World';
+      const data = {hello: 'Ignored'};
+      const result = evaluateTemplate(template, data);
+      expect(result).to.equal('Hello World');
+    });
+
+  });
 
   describe('#getFirstAssignee', function() {
 

--- a/src/weekly-notes/test.js
+++ b/src/weekly-notes/test.js
@@ -14,13 +14,16 @@ describe('weekly-notes/util', function() {
       expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 })).to.equal('W2 - 2000');
     });
 
+
     it('should calculate next week title correctly for week 1 with an empty custom template', function() {
       expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 }, '')).to.equal('W2 - 2000');
     });
 
+
     it('should calculate next week title correctly for week 1 with a custom template', function() {
       expect(getNextIssueTitle(1, { weekNumber: 1, year: 2000 }, 'Custom Template in week {{week}} of year {{year}}')).to.equal('Custom Template in week 2 of year 2000');
     });
+
 
     it('should calculate next week title correctly for 2 weeks ahead from week 1', function() {
       expect(getNextIssueTitle(2, { weekNumber: 1, year: 2000 })).to.equal('W3 - 2000');
@@ -65,6 +68,7 @@ describe('weekly-notes/util', function() {
       const result = evaluateTemplate(template, data);
       expect(result).to.equal('Hello World');
     });
+
 
     it('should evaluate a template without placeholders', function() {
       const template = 'Hello World';
@@ -114,6 +118,7 @@ describe('weekly-notes/util', function() {
       // then
       expect(assignee.login).to.equal('first');
     });
+
 
     it('should handle assignee tag in the middle of content', function() {
 

--- a/src/weekly-notes/test.js
+++ b/src/weekly-notes/test.js
@@ -68,7 +68,7 @@ describe('weekly-notes/util', function() {
 
     it('should evaluate a template without placeholders', function() {
       const template = 'Hello World';
-      const data = {hello: 'Ignored'};
+      const data = { hello: 'Ignored' };
       const result = evaluateTemplate(template, data);
       expect(result).to.equal('Hello World');
     });

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -40,6 +40,7 @@ module.exports.getWeek = function(date) {
  *   weekNumber: number,
  *   year: number
  * } } currentWeek
+ * @param {string} template
  *
  * @return {string}
  */

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -43,11 +43,16 @@ module.exports.getWeek = function(date) {
  *
  * @return {string}
  */
-module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, currentWeek) {
+module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, currentWeek, template) {
+
+  if(!template) {
+    template = 'W${week} - ${year}';
+  }
 
   console.debug('[weekly-notes] computing next issue title', {
     currentWeek,
-    weekInterval
+    weekInterval,
+    template
   });
 
   const {
@@ -57,9 +62,22 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
 
   const upcomingWeekNr = (Math.min(currentWeekNr, 52) + weekInterval - 1) % 52 + 1;
   const upcomingYearNr = upcomingWeekNr < currentWeekNr ? currentYearNr + 1 : currentYearNr;
-
-  return `W${upcomingWeekNr} - ${upcomingYearNr}`;
+  
+  return evaluateTemplate(template, { week: upcomingWeekNr, year: upcomingYearNr });
 };
+
+/**
+ * Evaluates a template literal with the provided data.
+ * 
+ * @param {string} template
+ * @param {Object} data
+ * @returns {string}
+ */
+function evaluateTemplate(template, data) {
+  const func = new Function(...Object.keys(data), `return \`${template}\`;`);
+  return func(...Object.values(data));
+}
+module.exports.evaluateTemplate = evaluateTemplate
 
 /**
  * @param {string} issueContents

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -74,8 +74,9 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
  * @returns {string}
  */
 function evaluateTemplate(template, data) {
-  const func = new Function(...Object.keys(data), `return \`${template}\`;`);
-  return func(...Object.values(data));
+  return template.replace(/\$\{(\w+)\}/g, (match, key) => {
+    return data.hasOwnProperty(key) ? data[key] : match;
+  });
 }
 module.exports.evaluateTemplate = evaluateTemplate;
 

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -75,7 +75,7 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
  */
 function evaluateTemplate(template, data) {
   return template.replace(/\$\{(\w+)\}/g, (match, key) => {
-    return data.hasOwnProperty(key) ? data[key] : match;
+    return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : match;
   });
 }
 module.exports.evaluateTemplate = evaluateTemplate;

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -46,7 +46,7 @@ module.exports.getWeek = function(date) {
 module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, currentWeek, template) {
 
   if (!template) {
-    template = 'W${week} - ${year}';
+    template = 'W{{week}} - {{year}}';
   }
 
   console.debug('[weekly-notes] computing next issue title', {
@@ -74,7 +74,7 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
  * @returns {string}
  */
 function evaluateTemplate(template, data) {
-  return template.replace(/\$\{(\w+)\}/g, (match, key) => {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
     return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : match;
   });
 }

--- a/src/weekly-notes/util.js
+++ b/src/weekly-notes/util.js
@@ -45,7 +45,7 @@ module.exports.getWeek = function(date) {
  */
 module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, currentWeek, template) {
 
-  if(!template) {
+  if (!template) {
     template = 'W${week} - ${year}';
   }
 
@@ -62,13 +62,13 @@ module.exports.getNextIssueTitle = function getNextIssueTitle(weekInterval, curr
 
   const upcomingWeekNr = (Math.min(currentWeekNr, 52) + weekInterval - 1) % 52 + 1;
   const upcomingYearNr = upcomingWeekNr < currentWeekNr ? currentYearNr + 1 : currentYearNr;
-  
+
   return evaluateTemplate(template, { week: upcomingWeekNr, year: upcomingYearNr });
 };
 
 /**
  * Evaluates a template literal with the provided data.
- * 
+ *
  * @param {string} template
  * @param {Object} data
  * @returns {string}
@@ -77,7 +77,7 @@ function evaluateTemplate(template, data) {
   const func = new Function(...Object.keys(data), `return \`${template}\`;`);
   return func(...Object.values(data));
 }
-module.exports.evaluateTemplate = evaluateTemplate
+module.exports.evaluateTemplate = evaluateTemplate;
 
 /**
  * @param {string} issueContents


### PR DESCRIPTION
This pull request adds support for customizable issue titles when creating weekly notes, allowing users to specify a template for the issue title that can reference the week and year. The changes include updates to the input handling, utility functions, and tests to ensure correct behavior.

**Customizable Issue Title Support:**

* Added a new input option `title-template` to the workflow, allowing users to provide a custom template for the issue title in `README.md`. 
* Updated `src/weekly-notes/index.js` to read the `title-template` input and pass it to the title generation function.
* Modified `getNextIssueTitle` in `src/weekly-notes/util.js` to accept an optional template parameter and use it to generate the issue title, defaulting to the original format if none is provided.
* Introduced a new utility function `evaluateTemplate` to safely interpolate values into the template string.
* Added and updated tests in `src/weekly-notes/test.js` to cover the new template functionality and the `evaluateTemplate` utility. 
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
