### PR TITLE
feat: Support custom issue label

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Automatically create the issue for the next modeling weekly.
 - `roles`: A comma-separated list of the roles you want to assign in the weekly.
 - `week-interval`: The time (in weeks) between two weeklies. Usefuly for biweekly and other cadences.
 - `title-template`: Optional issue title template literal that can reference the `{{week}}` and the `{{year}}`.
-- `label`: Optional issue label. Defaults to: `weekly`.
+- `label`: Label used to identify the issue. Defaults to: `weekly`.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Automatically create the issue for the next modeling weekly.
 - `roles`: A comma-separated list of the roles you want to assign in the weekly.
 - `week-interval`: The time (in weeks) between two weeklies. Usefuly for biweekly and other cadences.
 - `title-template`: Optional issue title template literal that can reference the `{{week}}` and the `{{year}}`.
+- `label`: Optional issue label. Defaults to: `weekly`.
 
 ### Outputs
 

--- a/src/weekly-notes/action.yml
+++ b/src/weekly-notes/action.yml
@@ -31,6 +31,11 @@ inputs:
     required: false
     default: 'W{{week}} - {{year}}'
     type: string
+  label:
+    description: 'Label used to identify the issue.'
+    required: false
+    default: 'weekly'
+    type: string
 outputs:
   html-url:
     description: 'The url of the created issue, if one was created'

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -22,8 +22,13 @@ async function run() {
   core.debug(`Available Moderators: ${JSON.stringify(MODERATORS)}`);
 
   const WEEKLY_TEMPLATE_PATH = core.getInput('template-path');
+  core.debug(`Template Path: ${JSON.stringify(WEEKLY_TEMPLATE_PATH)}`);
 
   const TITLE_TEMPLATE = core.getInput('title-template');
+  core.debug(`Title Template: ${JSON.stringify(TITLE_TEMPLATE)}`);
+
+  const LABEL = core.getInput('label')?.trim() || 'weekly';
+  core.debug(`Issue Label: ${JSON.stringify(LABEL)}`);
 
   const issue = github.context.payload.issue;
   core.debug(`Issue: ${JSON.stringify(issue)}`);
@@ -91,7 +96,7 @@ async function run() {
     return weeklyNote;
   };
 
-  if (!hasWeeklyLabel(issue)) {
+  if (!hasWeeklyLabel(issue, LABEL)) {
     return;
   }
 
@@ -142,7 +147,7 @@ async function run() {
   } = await _createIssue({
     body,
     title,
-    labels: [ 'weekly', 'ready' ],
+    labels: [ LABEL, 'ready' ],
     assignees
   });
 
@@ -173,12 +178,12 @@ run().catch((error) => {
 
 // helper ////////////////
 
-function hasWeeklyLabel(issue) {
+function hasWeeklyLabel(issue, label) {
   const {
     labels
   } = issue;
 
-  return !!find(labels, (l) => l.name === 'weekly');
+  return !!find(labels, (l) => l.name === label);
 }
 
 function alreadyCreated(weeklyTitle, issues) {

--- a/src/weekly-notes/index.js
+++ b/src/weekly-notes/index.js
@@ -27,8 +27,8 @@ async function run() {
   const TITLE_TEMPLATE = core.getInput('title-template');
   core.debug(`Title Template: ${JSON.stringify(TITLE_TEMPLATE)}`);
 
-  const LABEL = core.getInput('label')?.trim() || 'weekly';
-  core.debug(`Issue Label: ${JSON.stringify(LABEL)}`);
+  const WEEKLY_LABEL = core.getInput('label')?.trim() || 'weekly';
+  core.debug(`Issue Label: ${JSON.stringify(WEEKLY_LABEL)}`);
 
   const issue = github.context.payload.issue;
   core.debug(`Issue: ${JSON.stringify(issue)}`);
@@ -96,7 +96,7 @@ async function run() {
     return weeklyNote;
   };
 
-  if (!hasWeeklyLabel(issue, LABEL)) {
+  if (!hasLabel(issue, WEEKLY_LABEL)) {
     return;
   }
 
@@ -147,7 +147,7 @@ async function run() {
   } = await _createIssue({
     body,
     title,
-    labels: [ LABEL, 'ready' ],
+    labels: [ WEEKLY_LABEL, 'ready' ],
     assignees
   });
 
@@ -178,7 +178,7 @@ run().catch((error) => {
 
 // helper ////////////////
 
-function hasWeeklyLabel(issue, label) {
+function hasLabel(issue, label) {
   const {
     labels
   } = issue;


### PR DESCRIPTION
This pull request adds support for customizing the label used for weekly issues, making the workflow more flexible for teams that use different labeling conventions. The main changes involve introducing a new `label` input that defaults to `weekly`, updating the logic to use this label throughout the code, and improving debug output for easier troubleshooting.

Label customization and workflow updates:

* Added a new optional `label` input to the documentation in `README.md`, allowing users to specify a custom label for weekly issues.
* Updated the workflow to read the `label` input, defaulting to `weekly` if not provided, and added debug logging for the template path, title template, and label in `src/weekly-notes/index.js`.
* Modified the weekly label check to use the custom label instead of hardcoded `weekly`, updating both the function signature and its usage. [[1]](diffhunk://#diff-263250fcd972143dbb4edd0cd232e4d3d837f9000ecc975cb711ecc530bfdc23L94-R99) [[2]](diffhunk://#diff-263250fcd972143dbb4edd0cd232e4d3d837f9000ecc975cb711ecc530bfdc23L176-R186)
* Changed the issue creation logic to use the custom label when assigning labels to new issues, instead of always using `weekly`.### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
